### PR TITLE
Mulig fiks for produksjonsfeil

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -75,7 +75,10 @@
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-rt-ws-security</artifactId>
 		</dependency>
-		
+		<dependency>
+			<groupId>no.nav.tilbakemeldingsmottak</groupId>
+			<artifactId>web</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>


### PR DESCRIPTION
Dette er blitt fjernet i forrige commit. 
<dependency>
			<groupId>no.nav.tilbakemeldingsmottak</groupId>
			<artifactId>web</artifactId>
		</dependency>
Dette tilbakestilte endringer gjort her:
https://github.com/navikt/tilbakemeldingsmottak-api/commit/6a814eb07e99ae9585b98292796b4f96e2ca3d16
Som hadde denne info i commit mld
La til web-modulen i maven igjen, siden npm build i github actions ikke kunne erstatte det
