### PR TITLE
Schedule for sletting av Big Query serviceklager

### DIFF
--- a/app/src/main/java/no/nav/tilbakemeldingsmottak/bigquery/serviceklager/ServiceklageSlettScheduled.java
+++ b/app/src/main/java/no/nav/tilbakemeldingsmottak/bigquery/serviceklager/ServiceklageSlettScheduled.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-@Profile("nais")
+@Profile("nais | itest")
 public class ServiceklageSlettScheduled {
     private final BigQuery bigQueryClient;
 

--- a/app/src/main/java/no/nav/tilbakemeldingsmottak/bigquery/serviceklager/ServiceklageSlettScheduled.java
+++ b/app/src/main/java/no/nav/tilbakemeldingsmottak/bigquery/serviceklager/ServiceklageSlettScheduled.java
@@ -1,0 +1,60 @@
+package no.nav.tilbakemeldingsmottak.bigquery.serviceklager;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Profile("nais")
+public class ServiceklageSlettScheduled {
+    private final BigQuery bigQueryClient;
+
+    @Value("${big_query_dataset}")
+    private String dataset;
+
+    @Value("${gcp_team_project_id}")
+    private String projectId;
+
+    @Value("${cron.slettBigQueryServiceKlagerEldreEnn}")
+    private String slettBigQueryServiceKlagerEldreEnn;
+
+    private String slettEldreEnnQuery(String datoFelt, String eventType) {
+        return String.format(
+                "DELETE FROM `%s.%s.%s` " +
+                        "WHERE TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), %s, DAY) >= %s " +
+                        "AND event_type=%s",
+                projectId, dataset, ServiceklagerBigQuery.TABLE_NAME,
+                datoFelt, slettBigQueryServiceKlagerEldreEnn,
+                eventType
+        );
+    }
+
+    @Scheduled(cron = "${cron.slettBigQueryServiceKlagerScheduled}")
+    public void slettServiceKlager() {
+        try {
+            log.info("Sletter serviceklager eldre enn {} dager", slettBigQueryServiceKlagerEldreEnn);
+
+            // Slett alle opprettede serviceklager som er eldre enn 1 uke
+            var slettOpprettedeServiceklager = slettEldreEnnQuery("opprettet_dato", ServiceklageEventTypeEnum.OPPRETT_SERVICEKLAGE.value);
+            var slettOpprettedeServiceklagerQueryConfig = QueryJobConfiguration.newBuilder(slettOpprettedeServiceklager).build();
+            bigQueryClient.query(slettOpprettedeServiceklagerQueryConfig);
+
+            // Slett alle klassifiserte serviceklager som er eldre enn 1 uke
+            var slettKlassifiserteServiceklager = slettEldreEnnQuery("avsluttet_dato", ServiceklageEventTypeEnum.KLASSIFISER_SERVICEKLAGE.value);
+            var slettKlassifiserteServiceklagerQueryConfig = QueryJobConfiguration.newBuilder(slettKlassifiserteServiceklager).build();
+            bigQueryClient.query(slettKlassifiserteServiceklagerQueryConfig);
+
+        } catch (Exception e) {
+            log.error("Kunne ikke slette Big Query serviceklager eldre enn {} dager", slettBigQueryServiceKlagerEldreEnn, e);
+        }
+
+
+    }
+}

--- a/app/src/main/java/no/nav/tilbakemeldingsmottak/bigquery/serviceklager/ServiceklageSlettScheduled.java
+++ b/app/src/main/java/no/nav/tilbakemeldingsmottak/bigquery/serviceklager/ServiceklageSlettScheduled.java
@@ -40,14 +40,18 @@ public class ServiceklageSlettScheduled {
     public void slettServiceKlager() {
         try {
             log.info("Sletter serviceklager eldre enn {} dager", slettBigQueryServiceKlagerEldreEnn);
-
+            
             // Slett alle opprettede serviceklager som er eldre enn 1 uke
             var slettOpprettedeServiceklager = slettEldreEnnQuery("opprettet_dato", ServiceklageEventTypeEnum.OPPRETT_SERVICEKLAGE.value);
+            log.info("Query for sletting av opprettede serviceklager: {}", slettOpprettedeServiceklager);
+
             var slettOpprettedeServiceklagerQueryConfig = QueryJobConfiguration.newBuilder(slettOpprettedeServiceklager).build();
             bigQueryClient.query(slettOpprettedeServiceklagerQueryConfig);
 
             // Slett alle klassifiserte serviceklager som er eldre enn 1 uke
             var slettKlassifiserteServiceklager = slettEldreEnnQuery("avsluttet_dato", ServiceklageEventTypeEnum.KLASSIFISER_SERVICEKLAGE.value);
+            log.info("Query for sletting av klassifiserte serviceklager: {}", slettOpprettedeServiceklager);
+
             var slettKlassifiserteServiceklagerQueryConfig = QueryJobConfiguration.newBuilder(slettKlassifiserteServiceklager).build();
             bigQueryClient.query(slettKlassifiserteServiceklagerQueryConfig);
 

--- a/app/src/main/java/no/nav/tilbakemeldingsmottak/bigquery/serviceklager/ServiceklageSlettScheduled.java
+++ b/app/src/main/java/no/nav/tilbakemeldingsmottak/bigquery/serviceklager/ServiceklageSlettScheduled.java
@@ -29,7 +29,7 @@ public class ServiceklageSlettScheduled {
         return String.format(
                 "DELETE FROM `%s.%s.%s` " +
                         "WHERE TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), %s, DAY) >= %s " +
-                        "AND event_type=%s",
+                        "AND event_type='%s'",
                 projectId, dataset, ServiceklagerBigQuery.TABLE_NAME,
                 datoFelt, slettBigQueryServiceKlagerEldreEnn,
                 eventType
@@ -40,7 +40,7 @@ public class ServiceklageSlettScheduled {
     public void slettServiceKlager() {
         try {
             log.info("Sletter serviceklager eldre enn {} dager", slettBigQueryServiceKlagerEldreEnn);
-            
+
             // Slett alle opprettede serviceklager som er eldre enn 1 uke
             var slettOpprettedeServiceklager = slettEldreEnnQuery("opprettet_dato", ServiceklageEventTypeEnum.OPPRETT_SERVICEKLAGE.value);
             log.info("Query for sletting av opprettede serviceklager: {}", slettOpprettedeServiceklager);

--- a/app/src/main/java/no/nav/tilbakemeldingsmottak/config/SchedulingConfig.java
+++ b/app/src/main/java/no/nav/tilbakemeldingsmottak/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package no.nav.tilbakemeldingsmottak.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/app/src/main/resources/application-local.yml
+++ b/app/src/main/resources/application-local.yml
@@ -66,7 +66,7 @@ aad:
   tenant: tenant
 
 cron:
-    slettBigQueryServiceKlagerScheduled: "* */2 * * * *"
+    slettBigQueryServiceKlagerScheduled: "0 0 0 * * *" # midnatt hver dag
     slettBigQueryServiceKlagerEldreEnn: 7 # dager
 
 no.nav.security:

--- a/app/src/main/resources/application-local.yml
+++ b/app/src/main/resources/application-local.yml
@@ -65,6 +65,10 @@ aad:
   email: srvtilbakemeldings@trygdeetaten.no
   tenant: tenant
 
+cron:
+    slettBigQueryServiceKlagerScheduled: "* */2 * * * *"
+    slettBigQueryServiceKlagerEldreEnn: 7 # dager
+
 no.nav.security:
   jwt:
     client:

--- a/app/src/main/resources/application-nais.yml
+++ b/app/src/main/resources/application-nais.yml
@@ -57,6 +57,10 @@ aad:
   email: ${AAD_EMAIL}
   tenant: ${TENANT}
 
+cron:
+    slettBigQueryServiceKlagerScheduled: "* */2 * * * *"
+    slettBigQueryServiceKlagerEldreEnn: 7 # dager
+
 no.nav.security.jwt:
   client:
     registration:

--- a/app/src/main/resources/application-nais.yml
+++ b/app/src/main/resources/application-nais.yml
@@ -58,7 +58,7 @@ aad:
   tenant: ${TENANT}
 
 cron:
-    slettBigQueryServiceKlagerScheduled: "* */2 * * * *"
+    slettBigQueryServiceKlagerScheduled: "0 0 0 * * *" # midnatt hver dag
     slettBigQueryServiceKlagerEldreEnn: 7 # dager
 
 no.nav.security.jwt:

--- a/app/src/test/java/no/nav/tilbakemeldingsmottak/bigquery/serviceklager/ServiceklageSlettScheduledTest.java
+++ b/app/src/test/java/no/nav/tilbakemeldingsmottak/bigquery/serviceklager/ServiceklageSlettScheduledTest.java
@@ -1,0 +1,37 @@
+package no.nav.tilbakemeldingsmottak.bigquery.serviceklager;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import no.nav.tilbakemeldingsmottak.itest.ApplicationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.mockito.Mockito.*;
+
+public class ServiceklageSlettScheduledTest extends ApplicationTest {
+
+    @MockBean
+    private BigQuery bigQueryClient;
+
+    @Autowired
+    private ServiceklageSlettScheduled serviceklageSlettScheduled;
+
+    @Test
+    public void testSlettServiceKlager() throws InterruptedException {
+        // Gitt
+        String slettOpprettedeServiceklager = "DELETE FROM `gcp-team-project-id.dataset.serviceklager` WHERE TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), opprettet_dato, DAY) >= 7 AND event_type='OPPRETT_SERVICEKLAGE'";
+        String slettKlassifiserteServiceklager = "DELETE FROM `gcp-team-project-id.dataset.serviceklager` WHERE TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), avsluttet_dato, DAY) >= 7 AND event_type='KLASSIFISER_SERVICEKLAGE'";
+
+        QueryJobConfiguration slettOpprettedeServiceklagerQueryConfig = QueryJobConfiguration.newBuilder(slettOpprettedeServiceklager).build();
+        QueryJobConfiguration slettKlassifiserteServiceklagerQueryConfig = QueryJobConfiguration.newBuilder(slettKlassifiserteServiceklager).build();
+
+        // Når
+        serviceklageSlettScheduled.slettServiceKlager();
+
+        // Så
+        verify(bigQueryClient, times(1)).query(slettOpprettedeServiceklagerQueryConfig);
+        verify(bigQueryClient, times(1)).query(slettKlassifiserteServiceklagerQueryConfig);
+        verifyNoMoreInteractions(bigQueryClient);
+    }
+}

--- a/app/src/test/resources/application-itest.yml
+++ b/app/src/test/resources/application-itest.yml
@@ -27,6 +27,10 @@ aad:
   email: dummy@dummy.com
   tenant: tenant
 
+cron:
+    slettBigQueryServiceKlagerScheduled: "0 0 0 * * *" # midnatt hver dag
+    slettBigQueryServiceKlagerEldreEnn: 7 # dager
+
 no.nav.security:
   jwt:
     mock:

--- a/pdfutility/pom.xml
+++ b/pdfutility/pom.xml
@@ -163,7 +163,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <jvmTarget>${maven.compiler.target}</jvmTarget>
+                    <jvmTarget>${java.version}</jvmTarget>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
## Beskrivelse 

Datavarehus henter ut all dataen fra BQ regelmessig så vi kan fjerne alt her etter en uke. 

https://trello.com/c/sWlqvuXW/1354-slette-data-eldre-enn-en-uke-i-big-query