### PR TITLE
Korriger URL som kalles på tjenesten opprettJournalpost på dokarkiv

### DIFF
--- a/app/src/main/kotlin/no/nav/tilbakemeldingsmottak/consumer/joark/JournalpostConsumer.kt
+++ b/app/src/main/kotlin/no/nav/tilbakemeldingsmottak/consumer/joark/JournalpostConsumer.kt
@@ -39,7 +39,7 @@ class JournalpostConsumer(
 
         val journalpostReponse = restClient
             .method(HttpMethod.POST)
-            .uri("/journalpost/$FORSOEK_FERDIGSTILL")
+            .uri("/journalpost$FORSOEK_FERDIGSTILL")
             .contentType(APPLICATION_JSON)
             .accept(APPLICATION_JSON)
             .header("Nav-Callid", callId)


### PR DESCRIPTION
dokarkiv vil snart kun godta forespørsler uten trailing slash. Derfor må dette endres